### PR TITLE
Add optional backend flag to terraform init

### DIFF
--- a/docs/Terraform.md
+++ b/docs/Terraform.md
@@ -59,7 +59,7 @@ terraform.init(
   dir:        '/path/to/working_config_dir', // path to working config dir
   plugin_dir: '/path/to/plugin_dir', // optional path to (presumably shared) plugin/provider installation directory
   upgrade:    false, // optional upgrade modules and plugins
-  backend:    true  // optional initialize backend as configured (false to init re-usable modules)
+  backend:    true  // optional false to omit backend initialization
 )
 ```
 

--- a/docs/Terraform.md
+++ b/docs/Terraform.md
@@ -58,7 +58,8 @@ terraform.init(
   bin:        '/usr/bin/terraform', // optional path to terraform executable
   dir:        '/path/to/working_config_dir', // path to working config dir
   plugin_dir: '/path/to/plugin_dir', // optional path to (presumably shared) plugin/provider installation directory
-  upgrade:    false // optional upgrade modules and plugins
+  upgrade:    false, // optional upgrade modules and plugins
+  backend:    true  // optional initialize backend as configured (false to init re-usable modules)
 )
 ```
 

--- a/vars/terraform.groovy
+++ b/vars/terraform.groovy
@@ -184,6 +184,9 @@ void init(body) {
     if (config.upgrade == true) {
       cmd += ' -upgrade'
     }
+    if (config.backend == false) {
+      cmd += ' -backend=false'
+    }
 
     sh(label: 'Terraform Init', script: "${cmd} ${config.dir}")
   }


### PR DESCRIPTION
Running `terraform validate` requires an initialized working directory.  But if you want to validate without accessing any configured remote backend, you add the `-backend=false` flag to the `init` command.  This follows the suggested workflow in [the documentation](https://www.terraform.io/docs/commands/validate.html)